### PR TITLE
Fix #1

### DIFF
--- a/Twelve21.PasswordStorage/Twelve21.PasswordStorage.csproj
+++ b/Twelve21.PasswordStorage/Twelve21.PasswordStorage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Twelve21.PasswordStorage/Utilities/SystemManagement.cs
+++ b/Twelve21.PasswordStorage/Utilities/SystemManagement.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Management;
+﻿using System;
 
 namespace Twelve21.PasswordStorage.Utilities
 {
@@ -7,11 +6,7 @@ namespace Twelve21.PasswordStorage.Utilities
     {
         public static int GetTotalCpuCores()
         {
-            return new ManagementObjectSearcher("SELECT * FROM Win32_Processor")
-                .Get()
-                .Cast<ManagementBaseObject>()
-                .Select(mbo => int.Parse(mbo["NumberOfCores"].ToString()))
-                .Sum();
+            return Environment.ProcessorCount;
         }
     }
 }


### PR DESCRIPTION
Use the platform-agnostic Environment.ProcessorCount to get the number of logical processors that are available for use by the common language runtime (CLR).

Also, update the TargetFramework to the latest .NET Core version.